### PR TITLE
Add NVPTX architecture

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@ mod ad {
           target_arch = "mips64",
           target_arch = "sparc64",
           target_arch = "x86",
-          target_arch = "x86_64"))]
+          target_arch = "x86_64",
+          target_arch = "nvptx",
+          target_arch = "nvptx64"))]
 mod ad {
     pub type c_char = ::c_schar;
 }


### PR DESCRIPTION
Fix for error when building for NVPTX arch:

```
error[E0432]: unresolved import `ad::*`
  |
8 | pub use ad::*;
  |         ^^^^^^ Maybe a missing `extern crate ad;`?
```