### PR TITLE
Re-export core::ffi::c_void

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,15 +115,4 @@ pub type intptr_t = isize;
 pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
-// NOTE from libc v0.2.23
-// Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
-// more optimization opportunities around it recognizing things like
-// malloc/free.
-#[repr(u8)]
-pub enum c_void {
-    // Two dummy variants so the #[repr] attribute can be used.
-    #[doc(hidden)]
-    __variant1,
-    #[doc(hidden)]
-    __variant2,
-}
+pub type c_void = core::ffi::c_void;


### PR DESCRIPTION
https://github.com/japaric/cty/issues/10

Without this trying to use bindgen like:
```rust
let bindings = bindgen::Builder::default()
        .header("wrapper.h")
        .ctypes_prefix("cty")
        .use_core()
        .generate();
```

Results in lots of:
```
error[E0308]: mismatched types
  --> runng/src/protocol/mod.rs:49:43
   |
49 |         let res = nng_setopt(socket, opt, topic_ptr, topic_size);
   |                                           ^^^^^^^^^ expected enum `cty::c_void`, found enum `std::ffi::c_void`
   |
   = note: expected type `*const cty::c_void`
              found type `*const std::ffi::c_void`
```
