### PR TITLE
Fix cchar definition on aarch64 macos (e.g. M1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use od::*;
 // PWD = Pointer Width Dependent
 pub use pwd::*;
 
-#[cfg(any(target_arch = "aarch64",
+#[cfg(any(all(target_arch = "aarch64", not(target_os = "macos")),
           target_arch = "arm",
           target_arch = "asmjs",
           target_arch = "wasm32",
@@ -28,6 +28,16 @@ pub use pwd::*;
           target_arch = "riscv64"))]
 mod ad {
     pub type c_char = ::c_uchar;
+
+    pub type c_int = i32;
+    pub type c_uint = u32;
+}
+
+// TODO: Once https://github.com/rust-lang/rfcs/pull/2992 lands,
+// this should be extended to cover `aarch64-apple-ios-macabi`.
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+mod ad {
+    pub type c_char = ::c_schar;
 
     pub type c_int = i32;
     pub type c_uint = u32;


### PR DESCRIPTION
Fixes #18. Note that I'd also like to do something like this in test/test.rs, but it would only work on targets with libstd, which isn't something I know how to filter.

```rust
#[test]
fn check_vs_std() {
    let _: cty::c_char = 0 as std::os::raw::c_char;
    let _: cty::c_schar = 0 as std::os::raw::c_schar;
    let _: cty::c_uchar = 0 as std::os::raw::c_uchar;
    let _: cty::c_short = 0 as std::os::raw::c_short;
    let _: cty::c_ushort = 0 as std::os::raw::c_ushort;
    let _: cty::c_int = 0 as std::os::raw::c_int;
    let _: cty::c_uint = 0 as std::os::raw::c_uint;
    let _: cty::c_long = 0 as std::os::raw::c_long;
    let _: cty::c_ulong = 0 as std::os::raw::c_ulong;
    let _: cty::c_longlong = 0 as std::os::raw::c_longlong;
    let _: cty::c_ulonglong = 0 as std::os::raw::c_ulonglong;
}
```