### PR TITLE
first attempt at AVR architecture support (needed for arduino cross-compiling)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,14 @@ mod ad {
     pub type c_uint = u16;
 }
 
+#[cfg(target_arch = "avr")]
+mod ad {
+    pub type c_char = i8;
+    pub type c_int = i16;
+    pub type c_uint = u16;
+    // I hope the definitions for stuff like c_longlong are actually correct for AVR
+}
+
 // NOTE c_{,u}long definitions come from libc v0.2.3
 #[cfg(not(any(windows,
               target_os = "redox",
@@ -101,6 +109,9 @@ mod od {
 mod pwd {}
 
 #[cfg(target_pointer_width = "64")]
+mod pwd {}
+
+#[cfg(target_pointer_width = "16")]
 mod pwd {}
 
 pub type int8_t = i8;


### PR DESCRIPTION
When using `bindgen` to generate `bindings.rs` for Arduino libraries, we can not rely on the standard `ctypes_prefix()`.  The most common replacement is `cty`, but cty fails to compile on the AVR platform.

```
error[E0432]: unresolved import `ad`
  --> /home/thoth/.cargo/registry/src/github.com-1ecc6299db9ec823/cty-0.2.2/src/lib.rs:13:9
   |
13 | pub use ad::*;
   |         ^^ maybe a missing crate `ad`?

error[E0432]: unresolved import `pwd`
  --> /home/thoth/.cargo/registry/src/github.com-1ecc6299db9ec823/cty-0.2.2/src/lib.rs:17:9
   |
17 | pub use pwd::*;
   |         ^^^ maybe a missing crate `pwd`?

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0432`.
error: could not compile `cty`
```

This patch attempts to correct the problem.
