### PR TITLE
Add LOONGARCH64 support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ mod ad {
 
 #[cfg(any(target_arch = "mips",
           target_arch = "mips64",
+          target_arch = "loongarch64",
           target_arch = "sparc64",
           target_arch = "x86",
           target_arch = "x86_64",


### PR DESCRIPTION
I want to add loongarch64 support. This is a brief introduction to Loongarch ISA. You can get document from this[ link](https://loongson.github.io/LoongArch-Documentation/README-EN.html) . And some common FAQs from[ this](https://blog.xen0n.name/en/posts/tinkering/loongarch-faq/).

thanks